### PR TITLE
Sleet: remove accepted parents from tx

### DIFF
--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -61,8 +61,18 @@ impl<V: Clone + Eq + std::hash::Hash + std::fmt::Debug> DAG<V> {
     }
 
     /// Check if the given (parent) vertices exist
-    pub fn has_vertices(&self, vs: Vec<V>) -> bool {
-        vs.iter().all(|v| self.g.contains_key(v))
+    pub fn has_vertices(&self, vs: Vec<V>) -> std::result::Result<(), Vec<V>> {
+        let mut missing = vec![];
+        for v in vs.iter() {
+            if !self.g.contains_key(v) {
+                missing.push(v.clone());
+            }
+        }
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(missing)
+        }
     }
 
     /// Removes a vertex from the DAG. Outgoing and incoming edges are removed as well.
@@ -527,11 +537,11 @@ mod test {
         dag.insert_vx(2, vec![0]).unwrap();
         dag.insert_vx(3, vec![1, 2]).unwrap();
 
-        assert!(dag.has_vertices(vec![1, 2, 3]));
-        assert!(!dag.has_vertices(vec![1, 2, 3, 4]));
-        assert!(!dag.has_vertices(vec![4, 1, 2, 3]));
-        assert!(dag.has_vertices(vec![]));
-        assert!(!dag.has_vertices(vec![4]));
+        assert!(Ok(()) == dag.has_vertices(vec![1, 2, 3]));
+        assert!(Err(vec![4]) == dag.has_vertices(vec![1, 2, 3, 4]));
+        assert!(Err(vec![4]) == dag.has_vertices(vec![4, 1, 2, 3]));
+        assert!(Ok(()) == dag.has_vertices(vec![]));
+        assert!(Err(vec![4]) == dag.has_vertices(vec![4]));
     }
 
     #[actix_rt::test]

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -61,7 +61,7 @@ impl<V: Clone + Eq + std::hash::Hash + std::fmt::Debug> DAG<V> {
     }
 
     /// Check if the given (parent) vertices exist
-    pub fn has_vertices(&self, vs: Vec<V>) -> std::result::Result<(), Vec<V>> {
+    pub fn has_vertices(&self, vs: &Vec<V>) -> std::result::Result<(), Vec<V>> {
         let mut missing = vec![];
         for v in vs.iter() {
             if !self.g.contains_key(v) {
@@ -537,11 +537,11 @@ mod test {
         dag.insert_vx(2, vec![0]).unwrap();
         dag.insert_vx(3, vec![1, 2]).unwrap();
 
-        assert!(Ok(()) == dag.has_vertices(vec![1, 2, 3]));
-        assert!(Err(vec![4]) == dag.has_vertices(vec![1, 2, 3, 4]));
-        assert!(Err(vec![4]) == dag.has_vertices(vec![4, 1, 2, 3]));
-        assert!(Ok(()) == dag.has_vertices(vec![]));
-        assert!(Err(vec![4]) == dag.has_vertices(vec![4]));
+        assert!(Ok(()) == dag.has_vertices(&vec![1, 2, 3]));
+        assert!(Err(vec![4]) == dag.has_vertices(&vec![1, 2, 3, 4]));
+        assert!(Err(vec![4]) == dag.has_vertices(&vec![4, 1, 2, 3]));
+        assert!(Ok(()) == dag.has_vertices(&vec![]));
+        assert!(Err(vec![4]) == dag.has_vertices(&vec![4]));
     }
 
     #[actix_rt::test]

--- a/src/sleet/sleet.rs
+++ b/src/sleet/sleet.rs
@@ -106,7 +106,7 @@ impl Sleet {
             return Err(Error::InvalidCoinbaseTransaction(sleet_tx.cell));
         }
         if !tx_storage::is_known_tx(&self.known_txs, sleet_tx.hash()).unwrap() {
-            if let Err(_missing_parents) = self.dag.has_vertices(sleet_tx.parents.clone()) {
+            if !self.has_parents(&sleet_tx) {
                 return Err(Error::MissingAncestry);
             }
             self.insert(sleet_tx.clone())?;
@@ -123,10 +123,24 @@ impl Sleet {
     pub fn insert(&mut self, tx: Tx) -> Result<()> {
         let cell = tx.cell.clone();
         self.conflict_graph.insert_cell(cell.clone())?;
+        let tx = self.remove_accepted_parents(tx);
         self.dag.insert_vx(tx.hash(), tx.parents.clone())?;
         Ok(())
     }
 
+    pub fn has_parents(&self, tx: &Tx) -> bool {
+        match self.dag.has_vertices(&tx.parents) {
+            Ok(()) => true,
+            Err(missing_parents) => missing_parents.iter().all(|p| self.accepted_txs.contains(p)),
+        }
+    }
+
+    pub fn remove_accepted_parents(&self, mut tx: Tx) -> Tx {
+        let mut parents = tx.parents.clone();
+        parents.retain(|p| !self.accepted_txs.contains(p));
+        tx.parents = parents;
+        tx
+    }
     // Branch preference
 
     /// Starts at some vertex and does a depth first search in order to compute whether
@@ -670,7 +684,7 @@ impl Handler<CheckPending> for Sleet {
     fn handle(&mut self, _msg: CheckPending, ctx: &mut Context<Self>) -> Self::Result {
         let mut remaining = vec![];
         while let Some((tx, sender)) = self.pending_queries.pop() {
-            if let Ok(()) = self.dag.has_vertices(tx.parents.clone()) {
+            if self.has_parents(&tx) {
                 match self.on_receive_tx(tx.clone()) {
                     Ok(is_new) => {
                         if is_new {

--- a/src/sleet/sleet.rs
+++ b/src/sleet/sleet.rs
@@ -106,7 +106,7 @@ impl Sleet {
             return Err(Error::InvalidCoinbaseTransaction(sleet_tx.cell));
         }
         if !tx_storage::is_known_tx(&self.known_txs, sleet_tx.hash()).unwrap() {
-            if !self.dag.has_vertices(sleet_tx.parents.clone()) {
+            if let Err(_missing_parents) = self.dag.has_vertices(sleet_tx.parents.clone()) {
                 return Err(Error::MissingAncestry);
             }
             self.insert(sleet_tx.clone())?;
@@ -670,7 +670,7 @@ impl Handler<CheckPending> for Sleet {
     fn handle(&mut self, _msg: CheckPending, ctx: &mut Context<Self>) -> Self::Result {
         let mut remaining = vec![];
         while let Some((tx, sender)) = self.pending_queries.pop() {
-            if self.dag.has_vertices(tx.parents.clone()) {
+            if let Ok(()) = self.dag.has_vertices(tx.parents.clone()) {
                 match self.on_receive_tx(tx.clone()) {
                     Ok(is_new) => {
                         if is_new {


### PR DESCRIPTION
- `DAG::has_vertices` to return missing vertices on error